### PR TITLE
Updating readme to match current functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ of a project's package.json.
 It is currently not fit for external use.
 Please wait for 1.0.0 before relying on this tool.
 
-## prep command
-
-`npub prep`
-
-1. if no LICENSE file exists in the current directory, abort
-1. get a list of all files recursively in the current directory, excluding those in `publishConfig.license.exclude` (and `./node_modules`)
-1. for each file, ensure the LICENSE content is in a header comment
-
 ## publish command
 
 `npub version 1.2.3`
@@ -25,6 +17,7 @@ Please wait for 1.0.0 before relying on this tool.
 1. if git status is dirty, abort
 1. ensure license headers, if requested
 1. if git status is dirty, abort
+1. run the npm test suite
 1. build temp changelog based on commits since last version bump
 1. open editor with temp changelog
 1. if exit code is non-zero, abort
@@ -35,12 +28,13 @@ Please wait for 1.0.0 before relying on this tool.
 1. npm publish
 1. git push
 1. git push --tags
-1. update tag with release notes of this change's changelog
-1. comment on all PRs associated with this version with a link to the release notes
+1. npm publish
 
 ## todo
 
 * optionally provide github access to interact with pull requests and releases
+* update tag with release notes of this change's changelog
+* comment on all PRs associated with this version with a link to the release notes
 
 # license
 


### PR DESCRIPTION
This seems like a great time to cut and publish v0.9? v0.1? Anything really. We're ready to start testing this new `publish` command but it's not actually published anywhere.
