### PR TITLE
remove unused branch retrieval

### DIFF
--- a/lib/publish/index.js
+++ b/lib/publish/index.js
@@ -90,16 +90,13 @@ module.exports = function(dir, log, config, version, testCommand) {
                   endIf(error);
                   return prompt(version, function(error) {
                     endIf(error);
-                    return git.branch(function(error, branch) {
+                    return git.push(branch, function(error) {
                       endIf(error);
-                      return git.push(branch, function(error) {
+                      return git.pushTag(tag, function(error) {
                         endIf(error);
-                        return git.pushTag(tag, function(error) {
+                        return npm.publish(function(error) {
                           endIf(error);
-                          return npm.publish(function(error) {
-                            endIf(error);
-                            return log('success!');
-                          });
+                          return log('success!');
                         });
                       });
                     });

--- a/src/publish/index.coffee
+++ b/src/publish/index.coffee
@@ -78,20 +78,17 @@ module.exports = (dir, log, config, version, testCommand) ->
                   prompt version, (error) ->
                     endIf(error)
 
-                    git.branch (error, branch) ->
+                    git.push branch, (error) ->
                       endIf(error)
 
-                      git.push branch, (error) ->
+                      git.pushTag tag, (error) ->
                         endIf(error)
 
-                        git.pushTag tag, (error) ->
+                        npm.publish (error) ->
                           endIf(error)
 
-                          npm.publish (error) ->
-                            endIf(error)
+                          log 'success!'
 
-                            log 'success!'
-
-                            # TODO: github release notes
-                            # TODO: github PR comments
+                          # TODO: github release notes
+                          # TODO: github PR comments
 


### PR DESCRIPTION
The call to `git.branch` wasn't being used, it seems.