### PR TITLE
`git.remoteBranch` allows for remotes other than origin

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -43,21 +43,21 @@ module.exports = function(dir) {
         return callback(error);
       });
     },
-    branch: function(callback) {
-      debug("branch");
-      return exec("git rev-parse --abbrev-ref HEAD", options, function(error, stdout, stderr) {
+    remoteBranch: function(callback) {
+      debug("remoteBranch");
+      return exec("git rev-parse --abbrev-ref --symbolic-full-name @{u}", options, function(error, stdout, stderr) {
         return callback(error, stdout);
       });
     },
-    push: function(branch, callback) {
-      debug("push - " + branch);
-      return exec("git push origin " + branch, options, function(error, stdout, stderror) {
+    push: function(remote, branch, callback) {
+      debug("push - " + remote + " " + branch);
+      return exec("git push " + remote + " " + branch, options, function(error, stdout, stderror) {
         return callback(error);
       });
     },
-    pushTag: function(tag, callback) {
-      debug("pushTag - " + tag);
-      return exec("git push origin tag " + tag, options, function(error, stdout, stderror) {
+    pushTag: function(remote, tag, callback) {
+      debug("pushTag - " + remote + " " + tag);
+      return exec("git push " + remote + " tag " + tag, options, function(error, stdout, stderror) {
         return callback(error);
       });
     }

--- a/lib/publish/index.js
+++ b/lib/publish/index.js
@@ -88,15 +88,17 @@ module.exports = function(dir, log, config, version, testCommand) {
         return done(error, tag);
       });
     }, function(tag, done) {
-      return git.branch(function(error, branch) {
-        return done(error, branch, tag);
+      return git.remoteBranch(function(error, remoteBranch) {
+        var branch, ref, remote;
+        ref = remoteBranch != null ? remoteBranch.split('/') : void 0, remote = ref[0], branch = ref[1];
+        return done(error, remote, branch, tag);
       });
-    }, function(branch, tag, done) {
-      return git.push(branch, function(error) {
-        return done(error, tag);
+    }, function(remote, branch, tag, done) {
+      return git.push(remote, branch, function(error) {
+        return done(error, remote, tag);
       });
-    }, function(tag, done) {
-      return git.pushTag(tag, done);
+    }, function(remote, tag, done) {
+      return git.pushTag(remote, tag, done);
     }, function(done) {
       return npm.publish(done);
     }

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -36,21 +36,21 @@ module.exports = (dir) ->
     exec "git tag -a #{tag} -m #{tag}", options, (error, stdout, stderror) ->
       callback(error)
 
-  branch: (callback) ->
-    debug "branch"
+  remoteBranch: (callback) ->
+    debug "remoteBranch"
 
-    exec "git rev-parse --abbrev-ref HEAD", options, (error, stdout, stderr) ->
+    exec "git rev-parse --abbrev-ref --symbolic-full-name @{u}", options, (error, stdout, stderr) ->
       callback(error, stdout)
 
-  push: (branch, callback) ->
-    debug "push - #{branch}"
+  push: (remote, branch, callback) ->
+    debug "push - #{remote} #{branch}"
 
-    exec "git push origin #{branch}", options, (error, stdout, stderror) ->
+    exec "git push #{remote} #{branch}", options, (error, stdout, stderror) ->
       callback(error)
 
-  pushTag: (tag, callback) ->
-    debug "pushTag - #{tag}"
+  pushTag: (remote, tag, callback) ->
+    debug "pushTag - #{remote} #{tag}"
 
-    exec "git push origin tag #{tag}", options, (error, stdout, stderror) ->
+    exec "git push #{remote} tag #{tag}", options, (error, stdout, stderror) ->
       callback(error)
 

--- a/src/publish/index.coffee
+++ b/src/publish/index.coffee
@@ -80,15 +80,16 @@ module.exports = (dir, log, config, version, testCommand) ->
         done(error, tag)
 
     (tag, done) ->
-      git.branch (error, branch) ->
-        done(error, branch, tag)
+      git.remoteBranch (error, remoteBranch) ->
+        [remote, branch] = remoteBranch?.split('/')
+        done(error, remote, branch, tag)
 
-    (branch, tag, done) ->
-      git.push branch, (error) ->
-        done(error, tag)
+    (remote, branch, tag, done) ->
+      git.push remote, branch, (error) ->
+        done(error, remote, tag)
 
-    (tag, done) ->
-      git.pushTag tag, done
+    (remote, tag, done) ->
+      git.pushTag remote, tag, done
 
     (done) ->
       npm.publish done


### PR DESCRIPTION
We sometimes use a remote other than origin for our repo. This will look at the current branch and the remote branch it's tracking.

```bash
$ git rev-parse --abbrev-ref --symbolic-full-name @{u}
upstream/master
```